### PR TITLE
[#7] Restore session when reconnect to zookeeper

### DIFF
--- a/src/main/java/com/alipay/sofa/dashboard/client/listener/SofaDashboardClientApplicationContextRefreshedListener.java
+++ b/src/main/java/com/alipay/sofa/dashboard/client/listener/SofaDashboardClientApplicationContextRefreshedListener.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.dashboard.client.listener;
 
+import com.alipay.sofa.dashboard.client.model.ZkClientReconnectedEvent;
 import com.alipay.sofa.dashboard.client.registration.SofaDashboardClientRegister;
 import com.alipay.sofa.healthcheck.startup.ReadinessCheckListener;
 import org.slf4j.Logger;
@@ -24,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
 
 /**
  *
@@ -49,6 +51,19 @@ public class SofaDashboardClientApplicationContextRefreshedListener
     @Override
     public void onApplicationEvent(ContextRefreshedEvent event) {
         LOGGER.info("Start to register sofa dashboard client.");
+        doRegister();
+    }
+
+    @EventListener(ZkClientReconnectedEvent.class)
+    public void onEvent() {
+        LOGGER.info("Recover sofa dashboard client register.");
+        doRegister();
+    }
+
+    /**
+     * Check state from readiness check and do register
+     */
+    private void doRegister() {
         String status = readinessCheckListener.getHealthCheckerStatus()
                         && readinessCheckListener.getHealthCallbackStatus() ? Status.UP.toString()
             : Status.DOWN.toString();
@@ -57,4 +72,5 @@ public class SofaDashboardClientApplicationContextRefreshedListener
             LOGGER.info("sofa dashboard client register success.");
         }
     }
+
 }

--- a/src/main/java/com/alipay/sofa/dashboard/client/model/ZkClientReconnectedEvent.java
+++ b/src/main/java/com/alipay/sofa/dashboard/client/model/ZkClientReconnectedEvent.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.dashboard.client.model;
+
+/**
+ * Zookeeper client reconnected state event
+ *
+ * @author chen.pengzhi (chpengzh@foxmail.com)
+ * @since 2019-06-02 08:28
+ */
+public class ZkClientReconnectedEvent {
+}


### PR DESCRIPTION
zookeeper断线重连时对session node进行一次恢复

该实现逻辑类似于 [sofa-rpc/ZookeeperRegistry](https://github.com/sofastack/sofa-rpc/blob/e0369dd2da84ad9fad343bf4f50ca1ffeea56a80/extension-impl/registry-zk/src/main/java/com/alipay/sofa/rpc/registry/zk/ZookeeperRegistry.java#L237)

Tips: 如果是macbook进行测试，可以合上盖子进入待机状态大约30s。让进程进入suspended状态然后恢复，此时进程会 LOST->RECONNECTED, 执行一次恢复:

详情参考如下日志：

```log
019-06-02 08:50:10.458  INFO 26127 --- [(5)-10.37.129.2] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring FrameworkServlet 'dispatcherServlet'
2019-06-02 08:50:10.458  INFO 26127 --- [(5)-10.37.129.2] o.s.web.servlet.DispatcherServlet        : FrameworkServlet 'dispatcherServlet': initialization started
2019-06-02 08:50:10.475  INFO 26127 --- [(5)-10.37.129.2] o.s.web.servlet.DispatcherServlet        : FrameworkServlet 'dispatcherServlet': initialization completed in 17 ms
2019-06-02 08:50:59.008  INFO 26127 --- [127.0.0.1:2181)] org.apache.zookeeper.ClientCnxn          : Client session timed out, have not heard from server in 6571ms for sessionid 0x16b159ee79c001c, closing socket connection and attempting reconnect
2019-06-02 08:50:59.120  INFO 26127 --- [ain-EventThread] o.a.c.f.state.ConnectionStateManager     : State change: SUSPENDED
2019-06-02 08:51:00.476  INFO 26127 --- [127.0.0.1:2181)] org.apache.zookeeper.ClientCnxn          : Opening socket connection to server 127.0.0.1/127.0.0.1:2181. Will not attempt to authenticate using SASL (unknown error)
2019-06-02 08:51:00.476  INFO 26127 --- [127.0.0.1:2181)] org.apache.zookeeper.ClientCnxn          : Socket connection established to 127.0.0.1/127.0.0.1:2181, initiating session
2019-06-02 08:51:00.477  INFO 26127 --- [127.0.0.1:2181)] org.apache.zookeeper.ClientCnxn          : Unable to reconnect to ZooKeeper service, session 0x16b159ee79c001c has expired, closing socket connection
2019-06-02 08:51:00.477  WARN 26127 --- [ain-EventThread] org.apache.curator.ConnectionState       : Session expired event received
2019-06-02 08:51:00.478  INFO 26127 --- [ain-EventThread] org.apache.zookeeper.ZooKeeper           : Initiating client connection, connectString=127.0.0.1:2181 sessionTimeout=6000 watcher=org.apache.curator.ConnectionState@798cb6d9
2019-06-02 08:51:00.478  INFO 26127 --- [ain-EventThread] o.a.c.f.state.ConnectionStateManager     : State change: LOST
2019-06-02 08:51:00.478  INFO 26127 --- [ain-EventThread] org.apache.zookeeper.ClientCnxn          : EventThread shut down
2019-06-02 08:51:00.478  INFO 26127 --- [127.0.0.1:2181)] org.apache.zookeeper.ClientCnxn          : Opening socket connection to server 127.0.0.1/127.0.0.1:2181. Will not attempt to authenticate using SASL (unknown error)
2019-06-02 08:51:00.479  INFO 26127 --- [127.0.0.1:2181)] org.apache.zookeeper.ClientCnxn          : Socket connection established to 127.0.0.1/127.0.0.1:2181, initiating session
2019-06-02 08:51:00.491  INFO 26127 --- [127.0.0.1:2181)] org.apache.zookeeper.ClientCnxn          : Session establishment complete on server 127.0.0.1/127.0.0.1:2181, sessionid = 0x16b159ee79c0020, negotiated timeout = 6000
2019-06-02 08:51:00.491  INFO 26127 --- [ain-EventThread] o.a.c.f.state.ConnectionStateManager     : State change: RECONNECTED
2019-06-02 08:51:00.491  INFO 26127 --- [nStateManager-0] c.a.s.d.c.zookeeper.ZkCommandClient      : Reconnect to Zookeeper, ZkClientReconnectedEvent is called
2019-06-02 08:51:00.492  INFO 26127 --- [nStateManager-0] lientApplicationContextRefreshedListener : Recover sofa dashboard client register.
2019-06-02 08:51:00.505  INFO 26127 --- [nStateManager-0] lientApplicationContextRefreshedListener : sofa dashboard client register success.
```